### PR TITLE
支持x模式下目录遍历

### DIFF
--- a/plugins/gen_data_x.py
+++ b/plugins/gen_data_x.py
@@ -4,8 +4,15 @@ import os
 from langchain.vectorstores.faiss import FAISS
 from langchain.document_loaders import DirectoryLoader
 from langchain.text_splitter import TokenTextSplitter,CharacterTextSplitter
-floder='txt'
-files=os.listdir(floder)
+
+source_folder = 'txt'
+target_folder = 'txt_out'
+source_folder_path = os.path.join(os.getcwd(), source_folder)
+target_folder_path = os.path.join(os.getcwd(), target_folder)
+
+if not os.path.exists(target_folder_path):
+    os.mkdir(target_folder_path)
+
 def replaceall(mul,str):
     while str.find(mul) > -1:
         str = str.replace(mul,'')
@@ -14,20 +21,30 @@ def replace_all_double_n(str):
     while str.find('\n\n') > -1:
         str = str.replace('\n\n','\n')
     return str
-if not os.path.exists('txt_out'):
-    os.mkdir('txt_out')
-for file in files:
-    try:
-        with open(floder+'/'+file,"r",encoding='utf-16') as f:  
-            data = f.read()
-    except:
-            with open(floder+'/'+file,"r",encoding='utf-8') as f:  
+
+print(f'source_folder_path is: {source_folder_path}')
+root_path_list = source_folder_path.split(os.sep)
+
+for root, dirs, files in os.walk(source_folder_path):
+    path_list = root.split(os.sep)
+    for file in files:
+        try:
+            file_path = os.path.join(root,file)
+            with open(file_path,"r",encoding='utf-16') as f:  
+                 data = f.read()
+        except:
+            file_path = os.path.join(root,file)
+            with open(file_path,"r",encoding='utf-8') as f:  
                 data = f.read()
-    data=replace_all_double_n(data)
-    cut_file=f"txt_out/{file}"
-    with open(cut_file, 'w',encoding='utf-8') as f:   
-        f.write(data)
-        f.close()
+        data=replace_all_double_n(data)
+        filename_prefix_list = [item for item in path_list if item not in root_path_list]
+        file_name_prefix = '_'.join(x for x in filename_prefix_list if x)
+        cut_file_name = file_name_prefix + '_' + file if file_name_prefix else file
+        cut_file_path = os.path.join(target_folder_path, cut_file_name)
+        with open(cut_file_path, 'w',encoding='utf-8') as f:   
+            f.write(data)
+            f.close()
+
 print("开始读取数据")
 loader = DirectoryLoader('txt_out',glob='**/*.txt')
 docs = loader.load()


### PR DESCRIPTION
根据 [https://github.com/l15y/wenda/issues/69](https://github.com/l15y/wenda/issues/69) 的需求，增加x模式下遍历整个外部语料文件夹的功能，并将拼路径的逻辑全部标准化，方便日后扩展

为了避免文件重名
txt/样例1.txt
txt/文件夹1/样例2.txt
txt/文件夹1/文件夹A/样例3.txt

将会输出为：
txt_out/样例1.txt
txt_out/文件夹1_样例2.txt
txt_out/文件夹1_文件夹A_样例3.txt