### PR TITLE
修改了fess的查询方式

### DIFF
--- a/plugins/zhishiku_fess.py
+++ b/plugins/zhishiku_fess.py
@@ -19,19 +19,48 @@ def remove_stopwords(search_query):
     for i in search_query:
         try:
             stopwords.index(i)
+            search_query_without_stopwords.append("########")
         except:
             search_query_without_stopwords.append(i)
     return search_query_without_stopwords
+def removeduplicate(list1):
+    """
+    列表套字典去重复
+    :param list1: 输入一个有重复值的列表
+    :return: 返回一个去掉重复的列表
+    """
+    newlist = []
+    for i in list1:  # 先遍历原始字典
+        flag = True
+        if newlist == []:  # 如果是空的列表就不会有重复，直接往里添加
+            pass
+        else:
+            for j in newlist:
+                for key in i.keys():
+                    if i['_id']  == j['_id']:
+                        flag = False
+        if flag:
+            newlist.append(i)
+    return newlist
 def find(search_query,step = 0):
     try:
         search_query=jieba.cut(search_query)
         search_query=remove_stopwords(search_query)
         search_query=" ".join(search_query)
         print("关键词：",search_query)
-        url = 'http://' + settings.library.fess.Fess_Host + '/json/?q={}&num=10&sort=score.desc&lang=zh_CN'.format(search_query)
-        res = session.get(url, headers=headers, proxies=proxies)
-        r = res.json()
-        r=r["response"]['result']
+        rest = []
+        for i in search_query.split("########"):
+            if len(i.strip())>0:
+                url = 'http://' + settings.library.fess.Fess_Host + '/json/?q={}&num=10&sort=score.desc&lang=zh_CN'.format(i)
+                res = session.get(url, headers=headers, proxies=proxies)
+                r = res.json()
+                r=r["response"]['result']
+                # print('rrrrrrrrrrrrrrr',r)
+                rest.extend(r)
+            else:
+                continue
+        r = removeduplicate(rest)
+        # print('restrestrestrestrestrest', r)
         # "<strong>""</strong>"
         return [{'title': r[i]['title'], 'content':replace_strong(r[i]['content_description'])}
                 for i in range(min(int(settings.library.fess.Count), len(r)))]


### PR DESCRIPTION
目前zhishiku_fess.py的find采用去除stopwords之后再进行知识库查询
但是存在一个问题就是可能输入内容过多，知识库无法匹配到内容（fess本身的查询机制吧）
此处我在您去除stopwords的时候，方法体里加了一个分割，再进行分批次提交给fess查询，最后追加到一个list中，再根据_id去重。