### PR TITLE
Update gen_data_st.py

### DIFF
--- a/plugins/gen_data_st.py
+++ b/plugins/gen_data_st.py
@@ -104,7 +104,7 @@ for i in range(len(all_files)):
         with open(file_path, 'rb') as f:
             b = f.read()
             result = chardet.detect(b)
-        with open(file_path, 'r', encoding=result['encoding']) as f:
+        with open(file_path, 'r', encoding=result['encoding'], errors='ignore') as f:
             data = f.read()
     data = re.sub(r'[\n\r]+', "", data)
     data = re.sub(r'！', "！\n", data)


### PR DESCRIPTION
fix `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position XXX`

refers to https://stackoverflow.com/questions/42019117/unicodedecodeerror-charmap-codec-cant-decode-byte-0x8f-in-position-xxx-char

To reproduce this error, try this doc https://raw.githubusercontent.com/open-mmlab/mmdetection/v3.0.0rc5/README_zh-CN.md

![图片](https://user-images.githubusercontent.com/7872421/236217888-42f22fe4-32b4-4d31-bc7a-4c0e9ff90449.png)
