### PR TITLE
添加浏览网页内容的知识库脚本 

### DIFF
--- a/plugins/zhishiku_bingfull.py
+++ b/plugins/zhishiku_bingfull.py
@@ -10,7 +10,6 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 import time
-import pyperclip
 
 session = requests.Session()
 # 正则提取摘要和链接


### PR DESCRIPTION
在原zsk_bing的基础上，查看搜索结果链接中的网页内容，并获取正文部分作为知识库。测试在win11_64bit，3060-12G上完成。
在config.yml中使用bingfull调用。建议抽取数量<5个，一是因为添加了绕过反爬虫机制网页获取速度较慢，二是因为显存消耗较大。代码中已限制最大读取5个title。
获取的网页正文内容为链接brief的前后2600个字符。反爬虫机制为基于chrome的selenium，需要额外库文件selenium和BeautifulSoup。需要添加chrome的执行文件chromedriver_win.exe。该方案只对windows系统有效，linux系统的方法类似，但无法测试。已知在linux上移植需要的改动存在于：chrome的执行文件；修改selenium的Service参数。
正文内容的抽取方法来自https://zhuanlan.zhihu.com/p/26192335?utm_id=0